### PR TITLE
Extend Idle Detection Time.

### DIFF
--- a/SkyNX/source/main.c
+++ b/SkyNX/source/main.c
@@ -133,6 +133,7 @@ void init()
     startInput();
     startRender(videoContext);
     initGyro();
+    appletSetIdleTimeDetectionExtension(AppletIdleTimeDetectionExtension_ExtendedUnsafe);
 }
 void unInit()
 {


### PR DESCRIPTION
Not sure if this is something you want on by default. But when using this to stream a movie, youtube, etc, the switch's screen will dim after some time. This prevents that from happening.

I don't know how long the idle is, (there is no documentation on this) but it works and i've been testing it.

